### PR TITLE
move image creation to happen prior to writing page content to avoid mid object writing

### DIFF
--- a/run_build.sh
+++ b/run_build.sh
@@ -13,7 +13,7 @@ cd build
 
 cmake ..
 
-make && ./pdf_barcode ../sample-forms/label.pdf ../output/output1.pdf 1
-make && ./pdf_barcode ../sample-forms/label.pdf ../output/output2.pdf 0
+make && ./pdf_barcode ../sample-forms/label.pdf ../output/output1.pdf ../output/output1.log 1
+make && ./pdf_barcode ../sample-forms/label.pdf ../output/output2.pdf ../output/output2.log 0
 
 cd -


### PR DESCRIPTION
once a content context is started it should either be paused or ended prior to the writing of new objects.
the reason is simply that a content context itself represent an object - a pdf stream object - and it's only expected to have drawing commands there.
with the image form xobject being written after the content context started it can potentially create a corrupted pdf with the xobject code being written into the content stream.  the potentiality becomes an actuality with the modified page version, but could easily become a problem with the new page on modified doc if some drawing code was written prior to the creation of the form.

to resolve this issue, move the barcode image creation code either prior or post the content context, or pause the content context write the image object and only later restart the content context. in this example i just moved the image creation code to be prior to the context context to allow it to be properly drawn.

also:
- status must be initialized to be used later, so complemented that part
- deleted the modified page object to avoid leak (it's probably just as good to avoid dynamic allocation altogether)
- added new argv for the log. you don't want logs to be written into your pdf. that could easily corrupt it